### PR TITLE
[FE] 초기 필드 세팅 및 데이터 타입에 따라 프롬프트 예시 문구 변경

### DIFF
--- a/src/constants/categoryDataTypes.js
+++ b/src/constants/categoryDataTypes.js
@@ -5,11 +5,11 @@ export const CATEGORY_EXAMPLES = {
   "User Info": [
     {
       name: "Full Name",
-      examples: ["Alice Johnson", "Minho Kim", "Sophie Dubois"]
+      examples: ["Alice Johnson", "Bovin Kim", "Sophie Dubois"]
     },
     {
       name: "First Name",
-      examples: ["Alice", "Minho", "Sophie"]
+      examples: ["Alice", "Dahye", "Sophie"]
     },
     {
       name: "Last Name",
@@ -21,7 +21,7 @@ export const CATEGORY_EXAMPLES = {
     },
     {
       name: "Username",
-      examples: ["alicej88", "minho_k", "sophieD21"]
+      examples: ["Ensharp_Fighting", "geonwoo_choi", "sophieD21"]
     },
     {
       name: "Email Address",
@@ -33,7 +33,7 @@ export const CATEGORY_EXAMPLES = {
     },
     {
       name: "Phone",
-      examples: ["010-931-9062", "010-9062-1153", "010-1234-5678"]
+      examples: ["011-931-9062", "010-9062-1153", "010-1234-5678"]
     },
     {
       name: "Avatar",

--- a/src/features/synthorPage/components/FieldList/Constrains.jsx
+++ b/src/features/synthorPage/components/FieldList/Constrains.jsx
@@ -1,8 +1,24 @@
 
 import React from "react";
 import InputBox from "../../../../components/common/inputBox/InputBox";
+import { CATEGORY_PLACEHOLDERS } from "../../../../constants/categoryPlaceholders"
 
-export default function Constraints({ id, constraint, onChange }) {
+export default function Constraints({ id, constraint, onChange, selectedType }) {
+
+    // 선택된 타입의 placeholder 찾기
+    const placeholder = (() => {
+        if (!selectedType) return "constraint (e.g. under 40)";
+
+        for (const category in CATEGORY_PLACEHOLDERS) {
+            const match = CATEGORY_PLACEHOLDERS[category].find(
+                (item) => item.name === selectedType.name
+            );
+            if (match) return match.placeholder;
+        }
+
+        return "constraint (e.g. under 40)";
+    })();
+
     return (
         <div className="flex-1">
             <p className="text-s text-gray-200 mb-2">Constraints</p>
@@ -10,7 +26,7 @@ export default function Constraints({ id, constraint, onChange }) {
                 <InputBox
                     value={constraint}
                     onChange={(e) => onChange(id, "constraint", e.target.value)}
-                    placeholder="constraint (e.g. under 40)"
+                    placeholder={placeholder}
                     fullWidth={true}
                 />
             </div>

--- a/src/features/synthorPage/components/FieldList/FieldAssembly.jsx
+++ b/src/features/synthorPage/components/FieldList/FieldAssembly.jsx
@@ -23,7 +23,8 @@ export default function FieldAssembly({
                 {/* Data Type (모달 열기 버튼) */}
                 <button
                     onClick={() => onOpenTypeModal(id)}
-                    className="flex items-center w-[200px] rounded-[10px] px-4 py-2 bg-gray-800 text-white text-sm rounded hover:bg-gray-600 text-left">
+                    className="flex items-center w-[200px] rounded-[10px] px-4 py-2 bg-gray-800 text-white text-sm rounded hover:bg-gray-600 text-left"
+                >
                     {fieldType}
                     <img src={moveIcon} className="w-3 h-3 ml-auto" />
                 </button>

--- a/src/features/synthorPage/components/FieldList/FieldItem.jsx
+++ b/src/features/synthorPage/components/FieldList/FieldItem.jsx
@@ -77,6 +77,7 @@ export default function FieldItem({
                         id={id}
                         constraint={constraint}
                         onChange={onChange}
+                        selectedType={{ name: fieldType }}
                     />
 
                 </div>

--- a/src/features/synthorPage/hooks/useFieldList.js
+++ b/src/features/synthorPage/hooks/useFieldList.js
@@ -3,8 +3,8 @@ import { useState } from "react";
 export default function useFieldList() {
     const [fields, setFields] = useState([
         { id: "1", fieldName: "full_name", fieldType: "Full Name", constraint: "" },
-        { id: "1", fieldName: "gender", fieldType: "Gender", constraint: "" },
-        { id: "1", fieldName: "age", fieldType: "Number", constraint: "" },
+        { id: "2", fieldName: "gender", fieldType: "Gender", constraint: "" },
+        { id: "3", fieldName: "age", fieldType: "Number", constraint: "" },
     ]);
 
     const handleChange = (id, key, value) => {
@@ -18,16 +18,25 @@ export default function useFieldList() {
     };
 
     const handleAdd = () => {
-        setFields((prev) => [
-            ...prev,
-            {
-                id: Date.now().toString(),
+        setFields((prev) => {
+            const last = prev[prev.length - 1] || {
                 fieldName: "",
-                fieldType: "Full Name",
+                fieldType: "",
                 constraint: "",
-            },
-        ]);
+            };
+
+            return [
+                ...prev,
+                {
+                    id: last.id + 1,
+                    fieldName: last.fieldName,
+                    fieldType: last.fieldType,
+                    constraint: last.constraint,
+                },
+            ];
+        });
     };
+
 
     const reorderFields = (activeId, overId) => {
         setFields((prev) => {

--- a/src/features/synthorPage/hooks/useFieldList.js
+++ b/src/features/synthorPage/hooks/useFieldList.js
@@ -2,7 +2,9 @@ import { useState } from "react";
 
 export default function useFieldList() {
     const [fields, setFields] = useState([
-        { id: "1", fieldName: "", fieldType: "Full Name", constraint: "" },
+        { id: "1", fieldName: "full_name", fieldType: "Full Name", constraint: "" },
+        { id: "1", fieldName: "gender", fieldType: "Gender", constraint: "" },
+        { id: "1", fieldName: "age", fieldType: "Number", constraint: "" },
     ]);
 
     const handleChange = (id, key, value) => {


### PR DESCRIPTION
## 🚀 Topgun PR 요약
- 초기 화면 세팅에 3개의 필드를 고정함
- 데이터 타입에 따라 프롬프트 문구가 변경되도록 구현함

## ✅ 작업 내용
- [x] 데이터 타입 설정 시 그에 맞는 프롬프트 예시를 보여줌
- [x] 초기 화면에서 3개의 데이터 필드를 예시로 고정함 

## 🔗 관련 이슈
- Close #13 

## 🧪 테스트 내용
- [x] 로컬 환경 테스트

## 📝 기타 참고 사항
- 초기 화면 데이터  필드 3개 고정

<img width="1710" height="984" alt="스크린샷 2025-08-03 오전 8 48 23" src="https://github.com/user-attachments/assets/e0ae955f-2f3f-4049-9918-5def03b9cc20" />


- 데이터 타입에 따라 예시 문구 자동 적용
<img width="1632" height="414" alt="스크린샷 2025-08-03 오전 8 49 26" src="https://github.com/user-attachments/assets/d506a781-1e55-4eb1-ad61-f0aa23576a37" />


- 필드 추가 시 마지막 값이 자동으로 복사될 수 있게 함
(마지막 값인 Mac이 복사되어 빈 값이 들어감을 방지함)
<img width="1652" height="893" alt="스크린샷 2025-08-03 오전 8 52 10" src="https://github.com/user-attachments/assets/c06312d1-936b-41a0-b052-506ffdb1ae9b" />


