### PR TITLE
[FE] 리로드 시에 사용자 세팅값 초기화되도록 수정

### DIFF
--- a/src/features/synthorPage/SynthorPage.jsx
+++ b/src/features/synthorPage/SynthorPage.jsx
@@ -12,10 +12,31 @@ import useDownload from "../../hooks/useDownload";
 
 const ROWS_KEY = "synthor_rows";
 const PROMPT_KEY = "synthor_prompt";
+const FIELDS_KEY = "synthor_fields";
+
+const isHardReload = () => {
+    try {
+        const nav = performance.getEntriesByType?.("navigation")?.[0];
+        if (nav) return nav.type === "reload";
+        return performance.navigation?.type === 1;
+    } catch {
+        return false;
+    }
+};
+
+if (isHardReload()) {
+    try {
+        localStorage.removeItem(FIELDS_KEY);
+        localStorage.removeItem(ROWS_KEY);
+        localStorage.removeItem(PROMPT_KEY);
+    } catch { }
+}
 
 export default function SynthorPage() {
+
     const [isFormatOpen, setIsFormatOpen] = useState(false);
     const [prompt, setPrompt] = useState(() => localStorage.getItem(PROMPT_KEY) || "");
+
     const [rows, setRows] = useState(() => {
         const saved = localStorage.getItem(ROWS_KEY);
         return saved ? Number(saved) : 50;
@@ -32,7 +53,7 @@ export default function SynthorPage() {
             ...buildGeneratePayload(fieldList.fields, rows),
             ...(prompt ? { prompt } : {}),
         };
-        const format = "json"; // 필요 시 상태로 관리
+        const format = "json";
         const resp = await manualGenerate(format, payload);
         download(resp, { ext: format, filename: "synthorData" });
     };


### PR DESCRIPTION
## 🚀 Topgun PR 요약
[FE] 리로드 시에 사용자 세팅값 초기화되도록 수정

## ✅ 작업 내용
- [x] 버그 수정

## 🔗 관련 이슈
- Close #24 

## 📝 기타 참고 사항
- 기본 세팅값
- 새로고침 시, 사이트 진입 시에 필요한 기본값
<img width="1694" height="973" alt="스크린샷 2025-08-14 오후 3 53 29" src="https://github.com/user-attachments/assets/ebaa391a-5b01-4338-879a-f73161cfaac0" />


- 사용자 세팅값 
- 프리뷰 페이지에서 메인 페이지 이동 시에는 유지되도록 함 
<img width="1710" height="996" alt="스크린샷 2025-08-14 오후 3 53 54" src="https://github.com/user-attachments/assets/4482325e-4f4e-4aa2-9cb5-9b5943a6dfce" />
