### PR TITLE
[FE] 프리뷰 페이지를 모달로 변경하여 설정값 유지

### DIFF
--- a/src/features/previewPage/PreviewModal.jsx
+++ b/src/features/previewPage/PreviewModal.jsx
@@ -1,6 +1,5 @@
-// src/pages/preview/PreviewPage.jsx
+// src/pages/preview/PreviewModal.jsx
 import { useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
 import { manualGenerate } from "../../api/dataApi";
 import GenerateButton from "../../components/common/button/GenerateButton";
 import RowInputBox from "../../components/common/inputBox/RowInputBox";
@@ -8,11 +7,8 @@ import { buildGeneratePayload } from "../synthorPage/utils/buildPatload";
 import useDownload from "../../hooks/useDownload";
 import PreviewTable from "../previewPage/PreviewTable";
 
-export default function PreviewPage() {
-    const { state } = useLocation(); // { fields, format, prompt, initialCount }
-    const navigate = useNavigate();
+export default function PreviewModal({ open, onClose, state }) {
     const download = useDownload();
-
     const format = state?.format || "json";
     const fields = state?.fields || [];
     const prompt = state?.prompt;
@@ -20,12 +16,15 @@ export default function PreviewPage() {
     const [result, setResult] = useState(null);
     const [err, setErr] = useState(null);
 
-    // 최초 프리뷰 자동 생성
     useEffect(() => {
-        if (!state?.fields) {
-            navigate("/");
-            return;
-        }
+        if (!open) return;
+        const original = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => { document.body.style.overflow = original; };
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
         (async () => {
             try {
                 const payload = {
@@ -47,23 +46,15 @@ export default function PreviewPage() {
                 });
             }
         })();
-    }, [state, navigate, fields, rows, format, prompt]);
+    }, [open, fields, rows, format, prompt]);
 
-    // JSON 배열 여부 판정
-    const isJsonArray =
-        Array.isArray(result) ||
-        (typeof result === "string" &&
-            result.trim().startsWith("[") &&
-            result.trim().endsWith("]"));
-
-    // JSON 파싱 (배열만)
     const parsedJsonArray = useMemo(() => {
         if (Array.isArray(result)) return result;
         if (typeof result === "string") {
             try {
                 const parsed = JSON.parse(result);
                 return Array.isArray(parsed) ? parsed : null;
-            } catch {/* noop */ }
+            } catch { }
         }
         return null;
     }, [result]);
@@ -75,17 +66,13 @@ export default function PreviewPage() {
 
     const { previewInfo, textPreview } = useMemo(() => {
         const fallback = { previewInfo: { total: 0, shown: 0, label: "items" }, textPreview: null };
-
-        // JSON 배열이면 테이블에서 처리
         if (parsedJsonArray) {
             const total = parsedJsonArray.length;
             const shown = Math.min(100, total);
             return { previewInfo: { total, shown, label: "rows" }, textPreview: null };
         }
-
         if (typeof result === "string") {
             const raw = result;
-
             if (format === "csv") {
                 const lines = raw.split(/\r?\n/);
                 const header = lines[0] ?? "";
@@ -95,7 +82,6 @@ export default function PreviewPage() {
                 const preview = [header, ...dataLines.slice(0, shown)].join("\n");
                 return { previewInfo: { total, shown, label: "rows" }, textPreview: preview };
             }
-
             if (format === "ldif") {
                 const trimmed = raw.trim();
                 const records = trimmed.length ? trimmed.split(/\n\s*\n/) : [];
@@ -104,15 +90,12 @@ export default function PreviewPage() {
                 const preview = records.slice(0, shown).join("\n\n");
                 return { previewInfo: { total, shown, label: "records" }, textPreview: preview };
             }
-
-            // XML/HTML/SQL/그 외: 라인 기준
             const lines = raw.split(/\r?\n/);
             const total = lines.length;
             const shown = Math.min(100, total);
             const preview = lines.slice(0, shown).join("\n");
             return { previewInfo: { total, shown, label: "lines" }, textPreview: preview };
         }
-
         if (result != null) {
             const str = JSON.stringify(result, null, 2);
             const lines = str.split(/\r?\n/);
@@ -121,7 +104,6 @@ export default function PreviewPage() {
             const preview = lines.slice(0, shown).join("\n");
             return { previewInfo: { total, shown, label: "lines" }, textPreview: preview };
         }
-
         return fallback;
     }, [result, format, parsedJsonArray]);
 
@@ -148,64 +130,70 @@ export default function PreviewPage() {
         }
     };
 
+    if (!open) return null;
+
     return (
-        <div className="w-full min-h-screen bg-synthor flex flex-col">
-
-            <header className="h-[90px] bg-cyan-400 text-black font-bold text-2xl flex justify-between items-center -mt-6 -ml-6 -mr-6 px-6 rounded-t-[30px] shadow-[0_0_20px_5px_rgba(0,255,255,0.6)]">
-                <h1>Preview</h1>
-                <div className="flex items-center gap-3">
-                    <button
-                        className="text-2xl font-bold hover:opacity-80"
-                        onClick={() => window.history.back()}
-                    >
-                        ✕
-                    </button>
-                </div>
-            </header>
-
-            <main className="p-6 text-white flex-1">
-                {err && (
-                    <div className="text-red-400 text-sm border border-red-600 rounded-[10px] p-2 mb-4">
-                        {err.message || "Error"}
-                    </div>
-                )}
-
-                {!result && !err && <p>Synthor AI Loading...</p>}
-
-                {result && (
-                    <>
-                        <div className="text-xs text-gray-400 mb-2">
-                            Showing {previewInfo.shown} of {previewInfo.total} {previewInfo.label}
-                            {previewInfo.total > 100 && " (download includes all)"}
-                        </div>
-
-                        {parsedJsonArray ? (
-                            <PreviewTable rows={displayedRows} />
-                        ) : (
-                            <pre
-                                className="
-                  font-mono text-sm leading-7 tracking-wide
-                  whitespace-pre-wrap break-words
-                  bg-gray-900 text-gray-100
-                  p-4 rounded-lg border border-gray-700 shadow-inner
-                  max-h-[70vh] overflow-auto
-                "
+        <div className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/60">
+            <div className="w-[96vw] max-w-[1600px] h-[94vh] bg-synthor rounded-[20px] overflow-hidden shadow-[0_0_20px_5px_rgba(0,255,255,0.3)]">
+                <div className="grid grid-rows-[auto,1fr,auto] h-full min-h-0">
+                    <header className="bg-cyan-400 text-black font-bold text-2xl flex justify-between items-center px-6 py-4 rounded-t-[20px] shadow-[0_0_20px_5px_rgba(0,255,255,0.6)]">
+                        <h1>Preview</h1>
+                        <div className="flex items-center gap-3">
+                            <button
+                                className="text-2xl font-bold hover:opacity-80"
+                                onClick={onClose}
                             >
-                                {textPreview ??
-                                    (typeof result === "string" ? result : JSON.stringify(result, null, 2))}
-                            </pre>
-                        )}
-                    </>
-                )}
-            </main>
+                                ✕
+                            </button>
+                        </div>
+                    </header>
 
-            <div className="sticky bottom-0 -mx-6 px-6 py-4 bg-synthor/90 backdrop-blur border-t border-white/10">
-                <div className="flex flex-col md:flex-row items-stretch md:items-center gap-3 justify-end">
-                    <div className="w-full md:w-auto">
-                        <RowInputBox value={rows} onChange={setRows} />
-                    </div>
-                    <div className="w-full md:w-auto">
-                        <GenerateButton className="w-full md:w-auto" onClick={handleGenerateAndDownload} />
+
+                    <main className="p-6 text-white min-h-0 overflow-auto">
+                        {err && (
+                            <div className="text-red-400 text-sm border border-red-600 rounded-[10px] p-2 mb-4">
+                                {err.message || "Error"}
+                            </div>
+                        )}
+
+                        {!result && !err && <p>Synthor AI Loading...</p>}
+
+                        {result && (
+                            <>
+                                <div className="text-xs text-gray-400 mb-2">
+                                    Showing {previewInfo.shown} of {previewInfo.total} {previewInfo.label}
+                                    {previewInfo.total > 100 && " (download includes all)"}
+                                </div>
+
+                                {parsedJsonArray ? (
+                                    <PreviewTable rows={displayedRows} />
+                                ) : (
+                                    <pre
+                                        className="
+                      font-mono text-sm leading-7 tracking-wide
+                      whitespace-pre-wrap break-words
+                      bg-gray-900 text-gray-100
+                      p-4 rounded-lg border border-gray-700 shadow-inner
+                      max-h-[70vh] overflow-auto
+                    "
+                                    >
+                                        {textPreview ??
+                                            (typeof result === "string" ? result : JSON.stringify(result, null, 2))}
+                                    </pre>
+                                )}
+                            </>
+                        )}
+                    </main>
+
+                    <div className="px-6 py-4 bg-synthor/90 backdrop-blur border-t border-white/10">
+                        <div className="flex flex-col md:flex-row items-stretch md:items-center gap-3 justify-end">
+                            <div className="w-full md:w-auto">
+                                <RowInputBox value={rows} onChange={setRows} />
+                            </div>
+                            <div className="w-full md:w-auto">
+                                <GenerateButton className="w-full md:w-auto" onClick={handleGenerateAndDownload} />
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/features/synthorPage/SynthorPage.jsx
+++ b/src/features/synthorPage/SynthorPage.jsx
@@ -1,14 +1,16 @@
+
 import React, { useState, useEffect } from "react";
 import useFieldList from "../synthorPage/hooks/useFieldList";
 import FieldList from "./components/FieldList/FieldList";
 import DataGenerationPrompt from "./components/DataGenerationPrompt";
-import FormatSettingsModal from "./components/FormatSettingsModal"; // <- 위에서 만든 팝오버
+import FormatSettingsModal from "./components/FormatSettingsModal";
 import GenerateButton from "../../components/common/button/GenerateButton";
 import RowInputBox from "../../components/common/inputBox/RowInputBox";
 import PreviewButton from "./components/preview/PreviewButton";
 import { buildGeneratePayload } from "./utils/buildPatload";
 import { manualGenerate } from "../../api/dataApi";
 import useDownload from "../../hooks/useDownload";
+import PreviewModal from "../previewPage/PreviewModal";
 
 const ROWS_KEY = "synthor_rows";
 const PROMPT_KEY = "synthor_prompt";
@@ -36,8 +38,8 @@ if (isHardReload()) {
 
 export default function SynthorPage() {
     const [isFormatOpen, setIsFormatOpen] = useState(false);
+    const [isPreviewOpen, setIsPreviewOpen] = useState(false); // ✅ 모달 상태
 
-    // 기본값: 진입 시 or 사용자가 선택 안 했을 때 json
     const [format, setFormat] = useState(() => {
         return localStorage.getItem(FORMAT_KEY) || "json";
     });
@@ -103,7 +105,6 @@ export default function SynthorPage() {
 
                     <div className="flex items-center justify-between mt-6">
                         <div className="flex gap-4">
-
                             <div className="relative">
                                 <button
                                     onClick={() => setIsFormatOpen((v) => !v)}
@@ -124,10 +125,7 @@ export default function SynthorPage() {
                             </div>
 
                             <PreviewButton
-                                fields={fieldList.fields}
-                                format={format}
-                                prompt={prompt}
-                                count={rows}
+                                onOpen={() => setIsPreviewOpen(true)} // ✅ 라우팅 대신 모달 오픈
                             />
                         </div>
 
@@ -138,6 +136,18 @@ export default function SynthorPage() {
                     </div>
                 </div>
             </div>
+
+            {/* ✅ 프리뷰 모달 */}
+            <PreviewModal
+                open={isPreviewOpen}
+                onClose={() => setIsPreviewOpen(false)}
+                state={{
+                    fields: fieldList.fields,
+                    format,
+                    prompt,
+                    initialCount: rows,
+                }}
+            />
         </div>
     );
 }

--- a/src/features/synthorPage/components/FieldList/FieldItem.jsx
+++ b/src/features/synthorPage/components/FieldList/FieldItem.jsx
@@ -85,12 +85,18 @@ export default function FieldItem({
             {isTypeOpen && (
                 <DataTypeModal
                     initialType={initialType}
+
                     onClose={() => setIsTypeOpen(false)}
+
                     onSelectType={({ name, options: nextOptions, nullRatio: nextNull }) => {
+
                         onChange(id, "fieldType", name);
-                        onChange(id, "options", nextOptions);   // ✅ options에 제약 저장
+                        onChange(id, "options", nextOptions);
+
                         if (typeof nextNull === "number") onChange(id, "nullRatio", nextNull);
+
                         onSaveType?.(name, nextOptions, nextNull);
+
                         setIsTypeOpen(false);
                     }}
                 />

--- a/src/features/synthorPage/components/FieldList/FieldItem.jsx
+++ b/src/features/synthorPage/components/FieldList/FieldItem.jsx
@@ -2,18 +2,18 @@ import React, { useState } from "react";
 import FieldAssembly from "./FieldAssembly";
 import dragIcon from "../../../../assets/icons/SVG/dragIcon.svg";
 import deleteIcon from "../../../../assets/icons/SVG/deleteIcon.svg";
-
-
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import DataTypeModal from "../dataTypeModal/DataTypeModal";
-import Constraints from "./Constrains";
+import PromptInput from "./PromptInput";
 
 export default function FieldItem({
     id,
     fieldName,
     fieldType,
-    constraint,
+    prompt,
+    options,
+    nullRatio,
     onChange,
     onDelete,
     initialType,
@@ -34,17 +34,11 @@ export default function FieldItem({
         opacity: isDragging ? 0.5 : 1,
     };
 
-
     const [isTypeOpen, setIsTypeOpen] = useState(false);
 
     return (
-
-        <div
-            ref={setNodeRef}
-            style={style}
-            className="flex items-start gap-3 mb-4">
-
-            {/* 드래그 아이콘 (왼쪽 컨테이너) */}
+        <div ref={setNodeRef} style={style} className="flex items-start gap-3 mb-4">
+            {/* Drag */}
             <div
                 className="w-8 h-8 flex justify-center items-center cursor-grab active:cursor-grabbing mt-8"
                 {...attributes}
@@ -53,17 +47,13 @@ export default function FieldItem({
                 <img src={dragIcon} alt="drag" className="w-5 h-5" />
             </div>
 
-
-            {/* 필드 전체 컨테이너 */}
+            {/* 카드 */}
             <div className="flex-1 border border-gray-500 rounded-[15px] p-3 bg-transparent">
-
                 <div className="flex items-start justify-between gap-20">
-
+                    {/* Field Assembly */}
                     <div className="flex items-start justify-between flex-col">
-                        {/* Field Assembly (fieldName + fieldType) */}
                         <p className="text-s text-gray-200 mb-2">Field Assembly</p>
                         <div className="flex-1 border border-gray-700 rounded-[15px] p-2 bg-transparent focus-within:border-[#8E25E2] ">
-
                             <FieldAssembly
                                 id={id}
                                 fieldName={fieldName}
@@ -71,21 +61,19 @@ export default function FieldItem({
                                 onChange={onChange}
                                 onOpenTypeModal={() => setIsTypeOpen(true)}
                             />
-
                         </div>
                     </div>
 
-                    <Constraints
+                    <PromptInput
                         id={id}
-                        constraint={constraint}
+                        prompt={prompt}
                         onChange={onChange}
                         selectedType={{ name: fieldType }}
                     />
-
                 </div>
             </div>
 
-
+            {/* 삭제 */}
             <button
                 onClick={() => onDelete(id)}
                 className="ml-3 p-1 rounded hover:bg-gray-700/30 transition"
@@ -93,23 +81,20 @@ export default function FieldItem({
                 <img src={deleteIcon} alt="delete" className="w-7 h-7" />
             </button>
 
-            {/*모달*/}
+            {/* 타입 선택 모달 */}
             {isTypeOpen && (
                 <DataTypeModal
                     initialType={initialType}
                     onClose={() => setIsTypeOpen(false)}
-                    onSelectType={({ name, options, nullRatio }) => {
+                    onSelectType={({ name, options: nextOptions, nullRatio: nextNull }) => {
                         onChange(id, "fieldType", name);
-                        onChange(id, "options", options);
-                        onChange(id, "nullRatio", nullRatio); // optional: 화면에 보여주려면
-
-                        onSaveType(name, options, nullRatio);
+                        onChange(id, "options", nextOptions);   // ✅ options에 제약 저장
+                        if (typeof nextNull === "number") onChange(id, "nullRatio", nextNull);
+                        onSaveType?.(name, nextOptions, nextNull);
                         setIsTypeOpen(false);
                     }}
                 />
-
             )}
-
-        </div >
+        </div>
     );
 }

--- a/src/features/synthorPage/components/FieldList/PromptInput.jsx
+++ b/src/features/synthorPage/components/FieldList/PromptInput.jsx
@@ -1,27 +1,24 @@
-
 import React from "react";
 import InputBox from "../../../../components/common/inputBox/InputBox";
-import { CATEGORY_PLACEHOLDERS } from "../../../../constants/categoryPlaceholders"
+import { CATEGORY_PLACEHOLDERS } from "../../../../constants/categoryPlaceholders";
 
 export default function PromptInput({ id, prompt, onChange, selectedType }) {
-
-    // 선택된 타입의 placeholder 찾기
     const placeholder = (() => {
-
         for (const category in CATEGORY_PLACEHOLDERS) {
             const match = CATEGORY_PLACEHOLDERS[category].find(
-                (item) => item.name === selectedType.name
+                (item) => item.name === selectedType?.name
             );
             if (match) return match.placeholder;
         }
+        return "Describe the field you want (optional)";
     })();
 
     return (
         <div className="flex-1">
-            <p className="text-s text-gray-200 mb-2">Constraints Prompt</p>
+            <p className="text-s text-gray-200 mb-2">Prompt</p>
             <div className="flex-1 border border-gray-700 focus-within:border-[#8E25E2] rounded-[15px] p-2 bg-transparent">
                 <InputBox
-                    value={prompt}
+                    value={prompt ?? ""}
                     onChange={(e) => onChange(id, "prompt", e.target.value)}
                     placeholder={placeholder}
                     fullWidth={true}

--- a/src/features/synthorPage/components/FieldList/PromptInput.jsx
+++ b/src/features/synthorPage/components/FieldList/PromptInput.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import InputBox from "../../../../components/common/inputBox/InputBox";
 import { CATEGORY_PLACEHOLDERS } from "../../../../constants/categoryPlaceholders"
 
-export default function Constraints({ id, constraint, onChange, selectedType }) {
+export default function PromptInput({ id, prompt, onChange, selectedType }) {
 
     // 선택된 타입의 placeholder 찾기
     const placeholder = (() => {
@@ -18,11 +18,11 @@ export default function Constraints({ id, constraint, onChange, selectedType }) 
 
     return (
         <div className="flex-1">
-            <p className="text-s text-gray-200 mb-2">Constraints</p>
+            <p className="text-s text-gray-200 mb-2">Constraints Prompt</p>
             <div className="flex-1 border border-gray-700 focus-within:border-[#8E25E2] rounded-[15px] p-2 bg-transparent">
                 <InputBox
-                    value={constraint}
-                    onChange={(e) => onChange(id, "constraint", e.target.value)}
+                    value={prompt}
+                    onChange={(e) => onChange(id, "prompt", e.target.value)}
                     placeholder={placeholder}
                     fullWidth={true}
                 />

--- a/src/features/synthorPage/components/dataTypeModal/DataTypeModal.jsx
+++ b/src/features/synthorPage/components/dataTypeModal/DataTypeModal.jsx
@@ -8,7 +8,7 @@ import searchIcon from "../../../../assets/icons/SVG/searchIcon.svg";
 export default function DataTypeModal({
     onClose,
     onSelectType,
-    initialType, // { type, options, nullRatio }
+    initialType,
 }) {
     const [selectedCategory, setSelectedCategory] = useState("All");
     const [selectedType, setSelectedType] = useState(null); // { name, options? }

--- a/src/features/synthorPage/components/dataTypeModal/TypeConfigPanel.jsx
+++ b/src/features/synthorPage/components/dataTypeModal/TypeConfigPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import PasswordOptions from "./options/PasswordOptions";
-import DatetimeOptions from "./options/ DatetimeOptions";
+import DatetimeOptions from "./options/DatetimeOptions";
 import TimeOptions from "./options/TimeOptions";
 import UrlOptions from "./options/UrlOptions";
 import CreditCardTypeOptions from "./options/CreditCardTypeOptions";
@@ -19,7 +19,7 @@ export default function TypeConfigPanel({
     initialNullRatio = 0,
 }) {
     const [options, setOptions] = useState(initialOptions);
-    const [nullRatio, setNullRatio] = useState(initialNullRatio); // %
+    const [nullRatio, setNullRatio] = useState(initialNullRatio);
 
     // selectedType 또는 초기값이 바뀔 때 동기화
     useEffect(() => {

--- a/src/features/synthorPage/components/dataTypeModal/options/DatetimeOptions.jsx
+++ b/src/features/synthorPage/components/dataTypeModal/options/DatetimeOptions.jsx
@@ -12,7 +12,7 @@ export default function DatetimeOptions({ options, setOptions }) {
         setOptions((prev) => ({
             from: prev.from ?? formatDate(oneYearAgo),
             to: prev.to ?? formatDate(today),
-            format: prev.format ?? "m/d/yyyy",
+            format: prev.format ?? "M/d/yyyy",
             blank: prev.blank ?? 0,
         }));
     }, [setOptions]);
@@ -53,12 +53,12 @@ export default function DatetimeOptions({ options, setOptions }) {
                 className="w-full px-2 py-1 rounded bg-gray-800 border border-gray-600"
             >
                 {/* m/d/yyyy, mm/dd/yyyy, yyyy-mm-dd, yyyy-mm, d/m/yyyy, dd/mm/yyyy */}
-                <option value="m/d/yyyy">m/d/yyyy</option>
+                <option value="M/d/yyyy">M/d/yyyy</option>
                 <option value="yyyy-MM-dd">yyyy-MM-dd</option>
                 <option value="dd/MM/yyyy">dd/MM/yyyy</option>
-                <option value="yyyy-mm">yyyy-mm</option>
-                <option value="d/m/yyyy">d/m/yyyy</option>
-                <option value="dd/mm/yyyy">dd/mm/yyyy</option>
+                <option value="yyyy-MM">yyyy-mm</option>
+                <option value="d/M/yyyy">d/m/yyyy</option>
+                <option value="dd/MM/yyyy">dd/mm/yyyy</option>
             </select>
         </div>
     );

--- a/src/features/synthorPage/components/preview/PreviewButton.jsx
+++ b/src/features/synthorPage/components/preview/PreviewButton.jsx
@@ -1,16 +1,8 @@
-import { useNavigate } from "react-router-dom";
-
-export default function PreviewButton({ fields, format = "json", prompt, count = 50 }) {
-    const navigate = useNavigate();
-
-    const onClick = () => {
-
-        navigate("/preview", { state: { fields, format, prompt, initialCount: count } });
-    };
-
+// src/pages/synthorPage/components/preview/PreviewButton.jsx
+export default function PreviewButton({ onOpen }) {
     return (
         <button
-            onClick={onClick}
+            onClick={onOpen}
             className="w-[200px] h-[50px] bg-gray-700 rounded-[10px] hover:bg-gray-600"
         >
             Preview

--- a/src/features/synthorPage/hooks/useFieldList.js
+++ b/src/features/synthorPage/hooks/useFieldList.js
@@ -4,11 +4,22 @@ import { useEffect, useState } from "react";
 const LS_KEY = "synthor_fields";
 
 export default function useFieldList() {
+
   const [fields, setFields] = useState(() => {
+
     const saved = localStorage.getItem(LS_KEY);
     if (saved) {
-      try { return JSON.parse(saved); } catch { }
+      try {
+        const parsed = JSON.parse(saved);
+        return (parsed ?? []).map(f => ({
+          ...f,
+          prompt: f.prompt ?? "",
+          options: f.options ?? {},   // ✅ 누락 시만 채움
+        }));
+      } catch { }
     }
+
+
     // 초기 기본값
     return [
       { id: "1", fieldName: "full_name", fieldType: "Full Name", nullRatio: 0 },

--- a/src/features/synthorPage/hooks/useFieldList.js
+++ b/src/features/synthorPage/hooks/useFieldList.js
@@ -11,11 +11,11 @@ export default function useFieldList() {
     }
     // 초기 기본값
     return [
-      { id: "1", fieldName: "full_name", fieldType: "Full Name", options: {}, nullRatio: 0 },
-      { id: "2", fieldName: "email", fieldType: "Email Address", options: {}, nullRatio: 0 },
-      { id: "3", fieldName: "password", fieldType: "Password", options: {}, nullRatio: 0 },
-      { id: "4", fieldName: "age", fieldType: "Number", options: {}, nullRatio: 0 },
-      { id: "5", fieldName: "date", fieldType: "Datetime", options: {}, nullRatio: 0 },
+      { id: "1", fieldName: "full_name", fieldType: "Full Name", nullRatio: 0 },
+      { id: "2", fieldName: "email", fieldType: "Email Address", nullRatio: 0 },
+      { id: "3", fieldName: "password", fieldType: "Password", nullRatio: 0 },
+      { id: "4", fieldName: "age", fieldType: "Number", nullRatio: 0 },
+      { id: "5", fieldName: "date", fieldType: "Datetime", nullRatio: 0 },
     ];
   });
 
@@ -41,7 +41,6 @@ export default function useFieldList() {
           id: "1",
           fieldName: "full_name",
           fieldType: "Full name",
-          options: {},
           nullRatio: 0
         }];
       }

--- a/src/features/synthorPage/utils/buildPatload.js
+++ b/src/features/synthorPage/utils/buildPatload.js
@@ -97,10 +97,10 @@ export function buildGeneratePayload(fields, count = 3) {
             const base = {
                 name: f.fieldName,
                 type,
-                prompt: f.prompt,                         // 필드별 자연어 지시
-                constraints: f.options ?? {},             // 제약조건
+                prompt: f.prompt,
+                constraints: f.options ?? {},
                 nullablePercent: typeof f.nullRatio === "number" ? f.nullRatio : 0,
-                description: f.description,               // 선택
+                description: f.description,
             };
 
             // type이 fixed일 때만 value 포함

--- a/src/routes/AppRouter.jsx
+++ b/src/routes/AppRouter.jsx
@@ -1,14 +1,12 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
 import SynthorPage from "../features/synthorPage/SynthorPage"
-import PreviewPage from "../features/previewPage/PreviewPage"
 
 
 export default function AppRouter() {
     return (
         <Routes>
             <Route path="/" element={<SynthorPage />} />
-            <Route path="/preview" element={<PreviewPage />} />
         </Routes>
     );
 }


### PR DESCRIPTION
## 🚀 Topgun PR 요약
- 프리뷰 페이지를 모달로 변경하여 설정값 유지


## ✅ 작업 내용
- 기존 프리뷰 페이지를 모달창으로 변경
- 페이지 이동 시 프리뷰 상태(설정값)가 초기화되는 문제 해결
- 상태 유지를 위해 모달이 열려 있는 동안 컴포넌트 재마운트 방지

### 변경 이유
- 페이지 전환 시 기존 설정값이 사라져 재입력해야 하는 불편함 해소
- 사용자가 설정한 데이터 생성 옵션을 그대로 유지할 수 있도록 개선

### 기대 효과
- 페이지 이동 후에도 프리뷰 설정값 유지
- 사용자 경험(UX) 향상

## 🔗 관련 이슈
- Close #28 


## 📝 기타 참고 사항
![Uploading 스크린샷 2025-08-15 오전 2.52.29.png…]()
