### PR TITLE
[FE] 데이터 프롬프트 기능 구현 

### DIFF
--- a/src/api/dataApi.js
+++ b/src/api/dataApi.js
@@ -30,3 +30,14 @@ export async function manualGenerate(format, body) {
 
     return res.data;
 }
+
+
+
+export async function aiGenerate(body) {
+    // POST /api/data/ai-generate
+    const res = await axios.post("/api/data/ai-generate", body, {
+        headers: { "Content-Type": "application/json" },
+        responseType: "json",
+    });
+    return res.data;
+}

--- a/src/features/synthorPage/components/DataGenerationPrompt.jsx
+++ b/src/features/synthorPage/components/DataGenerationPrompt.jsx
@@ -1,24 +1,40 @@
 import React from "react";
+import SendIcon from "../../../assets/icons/SVG/sendIcon.svg";
 
-export default function DataGenerationPrompt({ value, onChange }) {
-    const hasValue = value.trim().length > 0;
+export default function DataGenerationPrompt({ value, onChange, onSend }) {
+    const hasValue = (value ?? "").trim().length > 0;
 
     return (
-
-        <div className="w-full">
+        <div className="relative w-full">
             <textarea
                 value={value}
-                onChange={(e) => onChange(e.target.value)}
-                placeholder="Describe the data you need. SYNTHOR AI will generate realistic values. 
-e.g. 100 Korean female users in their 20s with the last name Kim."
-
-                className={`w-full h-[80px] p-3 bg-synthor text-white rounded-md 
-                           placeholder-gray-500 outline-none transition-colors duration-200
-                           ${hasValue
+                onChange={(e) => onChange?.(e.target.value)}
+                placeholder={`Describe the data you need. SYNTHOR AI will generate realistic values.
+e.g. 100 Korean female users in their 20s with the last name Kim.`}
+                className={`w-full h-[80px] p-3 pr-10 bg-synthor text-white rounded-md
+                    placeholder-gray-500 outline-none transition-colors duration-200
+                    ${hasValue
                         ? "border-2 border-[#8E25E2]"
                         : "border border-white focus:border-2 focus:border-[#8E25E2]"
                     }`}
             />
+
+            {/* 전송 버튼 */}
+            <button
+                type="button"
+                onClick={onSend}
+                aria-label="Send prompt to AI"
+                className="absolute top-1/2 -translate-y-1/2 right-3 p-1 rounded-md
+             transition-transform duration-150 hover:scale-110 hover:bg-gray-600/40"
+            >
+                <img
+                    src={SendIcon}
+                    alt=""
+                    className="w-8 h-8"
+                />
+            </button>
+
+
         </div>
     );
 }

--- a/src/features/synthorPage/components/dataTypeModal/TypeConfigPanel.jsx
+++ b/src/features/synthorPage/components/dataTypeModal/TypeConfigPanel.jsx
@@ -30,7 +30,7 @@ export default function TypeConfigPanel({
         setNullRatio(
             typeof initialNullRatio === "number" ? initialNullRatio : 0
         );
-    }, [selectedType, initialNullRatio]);
+    }, [selectedType, initialNullRatio]); 1
 
     if (!selectedType) {
         return <div className="w-full h-full overflow-y-auto px-4 py-2" />;

--- a/src/features/synthorPage/utils/tyoeMapping.js
+++ b/src/features/synthorPage/utils/tyoeMapping.js
@@ -1,0 +1,70 @@
+
+export const TYPE_MAP = {
+    "Full Name": "full_name",
+    "First Name": "first_name",
+    "Last Name": "last_name",
+    "Phone": "phone",
+    "Address": "address",
+    "Street Address": "street_address",
+    "City": "city",
+    "State": "state",
+    "Country": "country",
+    "Postal Code": "postal_code",
+    "Company Name": "company_name",
+    "Job Title": "job_title",
+    "Department (Corporate)": "department_corporate",
+    "Department (Retail)": "department_retail",
+    "Product Name": "product_name",
+    "Product Category": "product_category",
+    "Catch Phrase": "catch_phrase",
+    "Product Description": "product_description",
+    "Language": "language",
+    "Color": "color",
+    "Username": "username",
+    "Password": "password",
+    "Email Address": "email_address",
+    "Domain Name": "domain_name",
+    "URL": "url",
+    "MAC Address": "mac_address",
+    "IPv4 Address": "ip_v4_address",
+    "IPv6 Address": "ip_v6_address",
+    "User Agent": "user_agent",
+    "Avatar": "avatar",
+    "App Name": "app_name",
+    "App Version": "app_version",
+    "Device Model": "device_model",
+    "Device Brand": "device_brand",
+    "Device OS": "device_os",
+    "Credit Card Number": "credit_card_number",
+    "Credit Card Type": "credit_card_type",
+    "Product Price": "product_price",
+    "Currency": "currency",
+    "IBAN": "iban",
+    "SWIFT/BIC": "swift_bic",
+    "Paragraphs": "paragraphs",
+    "Datetime": "datetime",
+    "Time": "time",
+    "Latitude": "latitude",
+    "Longitude": "longitude",
+    "Number": "number",
+    "Fixed": "fixed",
+};
+
+// UI -> 백엔드
+export function toBackendType(uiType) {
+    if (!uiType) return "string";
+    if (TYPE_MAP[uiType]) return TYPE_MAP[uiType];
+    return uiType.replaceAll(/\s+/g, "_").replaceAll(/[()]/g, "").toLowerCase();
+}
+
+// 백엔드 -> UI 
+const REVERSE_TYPE_MAP = Object.fromEntries(
+    Object.entries(TYPE_MAP).map(([ui, be]) => [be, ui])
+);
+
+export function toUIType(backendType) {
+    if (!backendType) return "Number";
+    return REVERSE_TYPE_MAP[backendType] ?? backendType
+        .replaceAll("_", " ")
+        .replace(/\b\w/g, (m) => m.toUpperCase());
+}


### PR DESCRIPTION
## 🚀 Topgun PR 요약
- 프롬프트 전송(POST /api/data/ai-generate) 도입 및 응답 기반 필드 일괄치환

## ✅ 작업 내용
- [x] 프롬프트 작성 후 전송 버튼 클릭 시: 네트워크 요청 바디는 { prompt }만 전송
- [x] 성공 시 수신한 fields로 필드 리스트가 즉시 갱신
- [x] 실패 시에는 아무 UI 변화 없도록 수정 
- FieldItem은 options, nullRatio, prompt prop을 받도록 이미 설계되어 있어 상위 FieldList에서 키만 맞추면 정상 반영됨.

## 🔗 관련 이슈
- Close #30 


## 📝 기타 참고 사항
- CORS/인증은 기존 axiosInstance 설정 준수

https://github.com/user-attachments/assets/b3edf52f-dc1b-4c10-aade-418d748b2225


